### PR TITLE
Fix crash with flipped camera on windows

### DIFF
--- a/modules/camera/camera_win.cpp
+++ b/modules/camera/camera_win.cpp
@@ -536,6 +536,12 @@ void CameraFeedWindows::read() {
 					flip_detected = (pitch < 0);
 					used_2d_buffer = true;
 
+					if (flip_detected) {
+						// scan_line points at the first visible row which is at the end of the memory block.
+						// Offset our data pointer back to the start of the block.
+						data -= buffer_length + pitch; // (pitch is negative here)
+					}
+
 					if (buffer_decoder) {
 						buffer_decoder->set_flip_vertical(flip_detected);
 					}


### PR DESCRIPTION
I gave this a try on Windows 10 (build 19045) with a Logitech HD Webcam C525 and got a crash in buffer_decoder.cpp trying to read `row_src` on line 206.

I had a look and discovered that [IMF2DBuffer::Lock2D](https://learn.microsoft.com/en-us/windows/win32/api/mfobjects/nf-mfobjects-imf2dbuffer-lock2d#remarks) returns a pointer to the last row in the memory block if the image is flipped, so advancing the pointer forward will read out of bounds.

Adjusting the pointer back to the start of the block fixes the issue and then everything seems to work great!
(I also checked the fallback standard buffer->Lock() and it doesn't seem to require this adjustment.)

Hope this helps, and thank you so much for working on this feature!