### PR TITLE
Web: Fix web CameraFeed reallocation

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -23,7 +23,7 @@ clangd:
   - "!**/*-so_wrap.{h,c}"
   - "!drivers/{apple*,core*,d3d12,metal,wasapi,windows,winmidi,xaudio2}/**"
   - "!editor/shader/shader_baker/shader_baker_export_plugin_platform_{d3d12,metal}.{h,cpp}"
-  - "!modules/camera/camera_{android,macos,win}.{h,cpp}"
+  - "!modules/camera/camera_{android,macos,web,win}.{h,cpp}"
   - "!modules/openxr/extensions/platform/openxr_{android,metal}_extension.{h,cpp}"
   - "!platform/{android,ios,macos,visionos,web,windows}/**"
   - "platform/{android,ios,macos,visionos,web,windows}/{api,export}/*.{h,hpp,hxx,hh,c,cpp,cxx,cc}"

--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -6,7 +6,7 @@
 	<description>
 		A camera feed gives you access to a single physical camera attached to your device. When enabled, Godot will start capturing frames from the camera which can then be used. See also [CameraServer].
 		[b]Note:[/b] Many cameras will return YCbCr images which are split into two textures and need to be combined in a shader. Godot does this automatically for you if you set the environment to show the camera image in the background.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, and iOS. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS and Web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -6,7 +6,7 @@
 	<description>
 		The [CameraServer] keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
 		It is notably used to provide AR modules with a video feed from the camera.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, and iOS. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS and Web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -6,7 +6,7 @@ Import("env_modules")
 
 env_camera = env_modules.Clone()
 
-if env["platform"] in ["windows", "macos", "linuxbsd", "android", "ios", "visionos"]:
+if env["platform"] in ["windows", "macos", "linuxbsd", "android", "ios", "visionos", "web"]:
     env_camera.add_source_files(env.modules_sources, "register_types.cpp")
 
 if env["platform"] == "windows":
@@ -29,3 +29,6 @@ elif env["platform"] == "linuxbsd":
     env_camera.add_source_files(env.modules_sources, "camera_linux.cpp")
     env_camera.add_source_files(env.modules_sources, "camera_feed_linux.cpp")
     env_camera.add_source_files(env.modules_sources, "buffer_decoder.cpp")
+
+elif env["platform"] == "web":
+    env_camera.add_source_files(env.modules_sources, "camera_web.cpp")

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -30,9 +30,9 @@
 
 #include "camera_web.h"
 
-#include "platform/web/camera_driver_web.h"
-
 #include "core/templates/hash_set.h"
+
+#include "platform/web/camera_driver_web.h"
 
 namespace {
 const String KEY_HEIGHT("height");

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -122,13 +122,9 @@ bool CameraFeedWeb::activate_feed() {
 	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
 	ERR_FAIL_NULL_V_MSG(driver, false, "CameraDriverWeb singleton is not initialized.");
 
-	// 'this' is passed as a raw context pointer to the JS callback.
-	// Safety assumption: Web builds are single-threaded (threads=no), so JS
-	// callbacks are dispatched synchronously on the same thread. deactivate_feed()
-	// calls stop_stream() which synchronously cancels all pending callbacks
-	// (cancelAnimationFrame / Worker.terminate), so no callback can fire after
-	// deactivate_feed() or the destructor returns.
-	// This invariant would break if Godot Web threads were ever enabled.
+	// 'this' is passed as a raw context pointer to JS. This is safe because
+	// Web builds are single-threaded - stop_stream() synchronously cancels all
+	// pending callbacks, so no callback can fire after deactivate_feed() returns.
 	driver->get_pixel_data(this, device_id, width, height,
 			&_on_get_pixel_data, &_on_denied_callback);
 	return true;

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -256,7 +256,7 @@ void CameraWeb::set_monitoring_feeds(bool p_monitoring_feeds) {
 	CameraServer::set_monitoring_feeds(p_monitoring_feeds);
 	if (p_monitoring_feeds) {
 		if (driver == nullptr) {
-			driver = new CameraDriverWeb();
+			driver = memnew(CameraDriverWeb);
 		}
 		_update_feeds();
 	} else {

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -30,6 +30,8 @@
 
 #include "camera_web.h"
 
+#include "platform/web/camera_driver_web.h"
+
 #include "core/templates/hash_set.h"
 
 namespace {

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -122,6 +122,13 @@ bool CameraFeedWeb::activate_feed() {
 	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
 	ERR_FAIL_NULL_V_MSG(driver, false, "CameraDriverWeb singleton is not initialized.");
 
+	// 'this' is passed as a raw context pointer to the JS callback.
+	// Safety assumption: Web builds are single-threaded (threads=no), so JS
+	// callbacks are dispatched synchronously on the same thread. deactivate_feed()
+	// calls stop_stream() which synchronously cancels all pending callbacks
+	// (cancelAnimationFrame / Worker.terminate), so no callback can fire after
+	// deactivate_feed() or the destructor returns.
+	// This invariant would break if Godot Web threads were ever enabled.
 	driver->get_pixel_data(this, device_id, width, height,
 			&_on_get_pixel_data, &_on_denied_callback);
 	return true;

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -1,0 +1,269 @@
+/**************************************************************************/
+/*  camera_web.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "camera_web.h"
+
+#include "core/templates/hash_set.h"
+
+namespace {
+const String KEY_HEIGHT("height");
+const String KEY_WIDTH("width");
+} // namespace
+
+void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_facing_mode, const char *p_error) {
+	// Validate context first to avoid dereferencing null on error paths.
+	ERR_FAIL_NULL_MSG(p_context, "Camera feed error: Null context received.");
+
+	CameraFeedWeb *feed = reinterpret_cast<CameraFeedWeb *>(p_context);
+
+	if (p_error) {
+		if (feed->is_active()) {
+			feed->deactivate_feed();
+		}
+		String error_str = String::utf8(p_error);
+		ERR_PRINT(vformat("Camera feed error from JS: %s", error_str));
+		return;
+	}
+
+	if (p_data == nullptr || p_length < 0 || p_width <= 0 || p_height <= 0) {
+		if (feed->is_active()) {
+			feed->deactivate_feed();
+		}
+		ERR_PRINT("Camera feed error: Invalid pixel data received.");
+		return;
+	}
+
+	// Update feed position based on facing mode.
+	// p_facing_mode: 0=unknown, 1=user/front, 2=environment/back
+	if (p_facing_mode == 1) {
+		feed->position = CameraFeed::FEED_FRONT;
+	} else if (p_facing_mode == 2) {
+		feed->position = CameraFeed::FEED_BACK;
+	}
+
+	Vector<uint8_t> &data = feed->data;
+	Ref<Image> image = feed->image;
+
+	const int64_t expected_size = Image::get_image_data_size(p_width, p_height, Image::FORMAT_RGBA8, false);
+	if (p_length < expected_size) {
+		if (feed->is_active()) {
+			feed->deactivate_feed();
+		}
+		ERR_PRINT("Camera feed error: Received pixel data smaller than expected.");
+		return;
+	}
+
+	if (data.size() != expected_size) {
+		data.resize(expected_size);
+	}
+	// Copy exactly the expected size (ignore any trailing bytes in 'p_data').
+	memcpy(data.ptrw(), p_data, expected_size);
+
+	image->initialize_data(p_width, p_height, false, Image::FORMAT_RGBA8, data);
+	feed->set_rgb_image(image);
+}
+
+void CameraFeedWeb::_on_denied_callback(void *p_context) {
+	ERR_FAIL_NULL_MSG(p_context, "Camera feed error: Null context received in denied callback.");
+	CameraFeedWeb *feed = reinterpret_cast<CameraFeedWeb *>(p_context);
+	feed->deactivate_feed();
+}
+
+bool CameraFeedWeb::activate_feed() {
+	if (is_active()) {
+		WARN_PRINT("Camera feed is already active.");
+		return true;
+	}
+	ERR_FAIL_COND_V_MSG(selected_format == -1, false, "CameraFeed format needs to be set before activating.");
+
+	// Initialize image when activating the feed.
+	if (image.is_null()) {
+		image.instantiate();
+	}
+
+	int width = parameters.get(KEY_WIDTH, 0);
+	int height = parameters.get(KEY_HEIGHT, 0);
+	// Defensive check in case formats list is shorter than expected.
+	if (formats.size() > selected_format) {
+		CameraFeed::FeedFormat f = formats[selected_format];
+		width = width > 0 ? width : f.width;
+		height = height > 0 ? height : f.height;
+	}
+
+	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
+	ERR_FAIL_NULL_V_MSG(driver, false, "CameraDriverWeb singleton is not initialized.");
+
+	driver->get_pixel_data(this, device_id, width, height,
+			&_on_get_pixel_data, &_on_denied_callback);
+	return true;
+}
+
+void CameraFeedWeb::deactivate_feed() {
+	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
+	ERR_FAIL_NULL_MSG(driver, "CameraDriverWeb singleton is not initialized.");
+	driver->stop_stream(device_id);
+
+	// Release the image when deactivating the feed.
+	image.unref();
+	data.clear();
+}
+
+bool CameraFeedWeb::set_format(int p_index, const Dictionary &p_parameters) {
+	ERR_FAIL_COND_V_MSG(active, false, "Feed is active.");
+	ERR_FAIL_INDEX_V_MSG(p_index, formats.size(), false, "Invalid format index.");
+
+	selected_format = p_index;
+	parameters = p_parameters.duplicate();
+	return true;
+}
+
+Array CameraFeedWeb::get_formats() const {
+	Array result;
+	for (const FeedFormat &feed_format : formats) {
+		Dictionary dictionary;
+		dictionary["width"] = feed_format.width;
+		dictionary["height"] = feed_format.height;
+		dictionary["format"] = feed_format.format;
+		dictionary["frame_numerator"] = feed_format.frame_numerator;
+		dictionary["frame_denominator"] = feed_format.frame_denominator;
+		result.push_back(dictionary);
+	}
+	return result;
+}
+
+CameraFeed::FeedFormat CameraFeedWeb::get_format() const {
+	CameraFeed::FeedFormat feed_format = {};
+	if (selected_format < 0 || selected_format >= formats.size()) {
+		return feed_format;
+	}
+	return formats[selected_format];
+}
+
+CameraFeedWeb::CameraFeedWeb(const CameraInfo &info) {
+	name = info.label;
+	device_id = info.device_id;
+	// Override base class default (Y-flip) with identity.
+	// Browser delivers frames already in the correct orientation.
+	transform = Transform2D();
+
+	for (int i = 0; i < info.formats.size(); i++) {
+		FeedFormat feed_format;
+		feed_format.width = info.formats[i].width;
+		feed_format.height = info.formats[i].height;
+		feed_format.format = String("RGBA");
+		// Web API provides frame rate as integer (max fps).
+		// Use frame_numerator/frame_denominator format consistent with other platforms.
+		if (info.formats[i].frame_rate > 0) {
+			feed_format.frame_numerator = info.formats[i].frame_rate;
+			feed_format.frame_denominator = 1;
+		}
+		formats.append(feed_format);
+	}
+}
+
+CameraFeedWeb::~CameraFeedWeb() {
+	if (is_active()) {
+		deactivate_feed();
+	}
+}
+
+void CameraWeb::_on_get_cameras_callback(void *p_context, const Vector<CameraInfo> &p_camera_info) {
+	CameraWeb *server = static_cast<CameraWeb *>(p_context);
+
+	// Build a set of new device IDs for quick lookup.
+	HashSet<String> new_device_ids;
+	for (int i = 0; i < p_camera_info.size(); i++) {
+		new_device_ids.insert(p_camera_info[i].device_id);
+	}
+
+	// Remove feeds that are no longer present.
+	for (int i = server->feeds.size() - 1; i >= 0; i--) {
+		Ref<CameraFeedWeb> feed = server->feeds[i];
+		if (feed.is_valid() && !new_device_ids.has(feed->get_device_id())) {
+			if (feed->is_active()) {
+				feed->deactivate_feed();
+			}
+			server->remove_feed(feed);
+		}
+	}
+
+	// Build a set of existing device IDs.
+	HashSet<String> existing_device_ids;
+	for (int i = 0; i < server->feeds.size(); i++) {
+		Ref<CameraFeedWeb> feed = server->feeds[i];
+		if (feed.is_valid()) {
+			existing_device_ids.insert(feed->get_device_id());
+		}
+	}
+
+	// Add new feeds that don't already exist.
+	for (int i = 0; i < p_camera_info.size(); i++) {
+		if (!existing_device_ids.has(p_camera_info[i].device_id)) {
+			Ref<CameraFeedWeb> feed = memnew(CameraFeedWeb(p_camera_info[i]));
+			server->add_feed(feed);
+		}
+	}
+
+	server->activating.clear();
+	server->call_deferred("emit_signal", SNAME(CameraServer::feeds_updated_signal_name));
+}
+
+void CameraWeb::_update_feeds() {
+	activating.set();
+	driver->get_cameras((void *)this, &_on_get_cameras_callback);
+}
+
+void CameraWeb::_cleanup() {
+	if (driver != nullptr) {
+		driver->stop_stream();
+		memdelete(driver);
+		driver = nullptr;
+	}
+}
+
+void CameraWeb::set_monitoring_feeds(bool p_monitoring_feeds) {
+	if (p_monitoring_feeds == monitoring_feeds || activating.is_set()) {
+		return;
+	}
+
+	CameraServer::set_monitoring_feeds(p_monitoring_feeds);
+	if (p_monitoring_feeds) {
+		if (driver == nullptr) {
+			driver = new CameraDriverWeb();
+		}
+		_update_feeds();
+	} else {
+		_cleanup();
+	}
+}
+
+CameraWeb::~CameraWeb() {
+	_cleanup();
+}

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -70,7 +70,6 @@ void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, c
 		feed->position = CameraFeed::FEED_BACK;
 	}
 
-	Vector<uint8_t> &data = feed->data;
 	Ref<Image> image = feed->image;
 
 	const int64_t expected_size = Image::get_image_data_size(p_width, p_height, Image::FORMAT_RGBA8, false);
@@ -82,13 +81,18 @@ void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, c
 		return;
 	}
 
-	if (data.size() != expected_size) {
-		data.resize(expected_size);
+	if (image.is_null()) {
+		image.instantiate();
+		feed->image = image;
 	}
-	// Copy exactly the expected size (ignore any trailing bytes in 'p_data').
-	memcpy(data.ptrw(), p_data, expected_size);
 
-	image->initialize_data(p_width, p_height, false, Image::FORMAT_RGBA8, data);
+	if (image->get_width() != p_width || image->get_height() != p_height || image->get_format() != Image::FORMAT_RGBA8 || image->has_mipmaps()) {
+		image->initialize_data(p_width, p_height, false, Image::FORMAT_RGBA8);
+	}
+
+	// Copy exactly the expected size (ignore any trailing bytes in 'p_data').
+	memcpy(image->ptrw(), p_data, expected_size);
+
 	feed->set_rgb_image(image);
 }
 
@@ -137,7 +141,6 @@ void CameraFeedWeb::deactivate_feed() {
 
 	// Release the image when deactivating the feed.
 	image.unref();
-	data.clear();
 }
 
 bool CameraFeedWeb::set_format(int p_index, const Dictionary &p_parameters) {

--- a/modules/camera/camera_web.h
+++ b/modules/camera/camera_web.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  camera_web.h                                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,46 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#if defined(LINUXBSD_ENABLED)
-#include "camera_linux.h"
-#endif
-#if defined(WINDOWS_ENABLED)
-#include "camera_win.h"
-#endif
-#if defined(MACOS_ENABLED)
-#include "camera_apple.h"
-#endif
-#if defined(ANDROID_ENABLED)
-#include "camera_android.h"
-#endif
-#if defined(WEB_ENABLED)
-#include "camera_web.h"
-#endif
+#include "servers/camera/camera_feed.h"
+#include "servers/camera/camera_server.h"
 
-void initialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+#include "platform/web/camera_driver_web.h"
 
-#if defined(LINUXBSD_ENABLED)
-	CameraServer::make_default<CameraLinux>();
-#endif
-#if defined(WINDOWS_ENABLED)
-	CameraServer::make_default<CameraWindows>();
-#endif
-#if defined(MACOS_ENABLED)
-	CameraServer::make_default<CameraApple>();
-#endif
-#if defined(ANDROID_ENABLED)
-	CameraServer::make_default<CameraAndroid>();
-#endif
-#if defined(WEB_ENABLED)
-	CameraServer::make_default<CameraWeb>();
-#endif
-}
+class CameraFeedWeb : public CameraFeed {
+	GDSOFTCLASS(CameraFeedWeb, CameraFeed);
 
-void uninitialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-}
+	String device_id;
+	Ref<Image> image;
+	Vector<uint8_t> data;
+
+	static void _on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_facing_mode, const char *p_error);
+	static void _on_denied_callback(void *p_context);
+
+public:
+	bool activate_feed() override;
+	void deactivate_feed() override;
+	bool set_format(int p_index, const Dictionary &p_parameters) override;
+	Array get_formats() const override;
+	FeedFormat get_format() const override;
+	String get_device_id() const { return device_id; }
+
+	CameraFeedWeb(const CameraInfo &info);
+	~CameraFeedWeb();
+};
+
+class CameraWeb : public CameraServer {
+	GDSOFTCLASS(CameraWeb, CameraServer);
+
+	CameraDriverWeb *driver = nullptr;
+	SafeFlag activating;
+	void _cleanup();
+	void _update_feeds();
+	static void _on_get_cameras_callback(void *p_context, const Vector<CameraInfo> &p_camera_info);
+
+public:
+	void set_monitoring_feeds(bool p_monitoring_feeds) override;
+
+	~CameraWeb();
+};

--- a/modules/camera/camera_web.h
+++ b/modules/camera/camera_web.h
@@ -33,7 +33,7 @@
 #include "servers/camera/camera_feed.h"
 #include "servers/camera/camera_server.h"
 
-// Shared camera data types — kept in a platform/web-level header so this
+// Shared camera data types, kept in a platform/web-level header so this
 // module does not need to include the full CameraDriverWeb driver header.
 #include "platform/web/camera_types_web.h"
 

--- a/modules/camera/camera_web.h
+++ b/modules/camera/camera_web.h
@@ -44,7 +44,6 @@ class CameraFeedWeb : public CameraFeed {
 
 	String device_id;
 	Ref<Image> image;
-	Vector<uint8_t> data;
 
 	static void _on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_facing_mode, const char *p_error);
 	static void _on_denied_callback(void *p_context);

--- a/modules/camera/config.py
+++ b/modules/camera/config.py
@@ -10,6 +10,7 @@ def can_build(env, platform):
         or platform == "android"
         or platform == "ios"
         or platform == "visionos"
+        or platform == "web"
     )
 
 

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -22,6 +22,7 @@ if "serve" in COMMAND_LINE_TARGETS or "run" in COMMAND_LINE_TARGETS:
 
 web_files = [
     "audio_driver_web.cpp",
+    "camera_driver_web.cpp",
     "webmidi_driver.cpp",
     "display_server_web.cpp",
     "http_client_web.cpp",
@@ -36,6 +37,7 @@ if env["target"] == "editor":
 sys_env = env.Clone()
 sys_env.AddJSLibraries([
     "js/libs/library_godot_audio.js",
+    "js/libs/library_godot_camera.js",
     "js/libs/library_godot_display.js",
     "js/libs/library_godot_emscripten.js",
     "js/libs/library_godot_fetch.js",

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -66,8 +66,14 @@ int CameraDriverWeb::_get_int_value(const Variant &p_val) {
 }
 
 void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, const char *json_ptr) {
+	// Always call the user callback — even on error — so callers can clear any
+	// in-progress flags (e.g. CameraWeb::activating) regardless of outcome.
+	CameraDriverWebGetCamerasCallback on_get_cameras_callback =
+			reinterpret_cast<CameraDriverWebGetCamerasCallback>(callback);
+
 	if (!json_ptr) {
 		ERR_PRINT("CameraDriverWeb::_on_get_cameras_callback: json_ptr is null.");
+		on_get_cameras_callback(context, Vector<CameraInfo>());
 		return;
 	}
 	String json_string = String::utf8(json_ptr);
@@ -75,6 +81,7 @@ void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, co
 
 	if (json_variant.get_type() != Variant::DICTIONARY) {
 		ERR_PRINT("CameraDriverWeb::_on_get_cameras_callback: Failed to parse JSON response or response is not a Dictionary.");
+		on_get_cameras_callback(context, Vector<CameraInfo>());
 		return;
 	}
 
@@ -83,12 +90,14 @@ void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, co
 	if (v_error.get_type() == Variant::STRING) {
 		String error_str = v_error;
 		ERR_PRINT(vformat("Camera error from JS: %s", error_str));
+		on_get_cameras_callback(context, Vector<CameraInfo>());
 		return;
 	}
 
 	Variant v_devices = json_dict.get(KEY_CAMERAS, Variant());
 	if (v_devices.get_type() != Variant::ARRAY) {
 		ERR_PRINT("Camera error: 'cameras' is not an array or missing.");
+		on_get_cameras_callback(context, Vector<CameraInfo>());
 		return;
 	}
 
@@ -147,7 +156,6 @@ void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, co
 		camera_info.push_back(info);
 	}
 
-	CameraDriverWebGetCamerasCallback on_get_cameras_callback = reinterpret_cast<CameraDriverWebGetCamerasCallback>(callback);
 	on_get_cameras_callback(context, camera_info);
 }
 

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -1,0 +1,178 @@
+/**************************************************************************/
+/*  camera_driver_web.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "camera_driver_web.h"
+
+#include "godot_camera.h"
+
+#include "core/io/json.h"
+
+#include <cstdlib>
+
+namespace {
+const String KEY_CAMERAS("cameras");
+const String KEY_ERROR("error");
+const String KEY_FORMATS("formats");
+const String KEY_FRAME_RATE("frameRate");
+const String KEY_HEIGHT("height");
+const String KEY_ID("id");
+const String KEY_INDEX("index");
+const String KEY_LABEL("label");
+const String KEY_WIDTH("width");
+} // namespace
+
+CameraDriverWeb *CameraDriverWeb::singleton = nullptr;
+Array CameraDriverWeb::_camera_info_key;
+
+CameraDriverWeb *CameraDriverWeb::get_singleton() {
+	return singleton;
+}
+
+// Helper to extract integer value from Variant.
+int CameraDriverWeb::_get_int_value(const Variant &p_val) {
+	if (p_val.get_type() == Variant::INT) {
+		return p_val;
+	} else if (p_val.get_type() == Variant::FLOAT) {
+		return static_cast<int>(p_val.operator float());
+	}
+	return 0;
+}
+
+void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, const char *json_ptr) {
+	if (!json_ptr) {
+		ERR_PRINT("CameraDriverWeb::_on_get_cameras_callback: json_ptr is null.");
+		return;
+	}
+	String json_string = String::utf8(json_ptr);
+	Variant json_variant = JSON::parse_string(json_string);
+
+	if (json_variant.get_type() != Variant::DICTIONARY) {
+		ERR_PRINT("CameraDriverWeb::_on_get_cameras_callback: Failed to parse JSON response or response is not a Dictionary.");
+		return;
+	}
+
+	Dictionary json_dict = json_variant;
+	Variant v_error = json_dict[KEY_ERROR];
+	if (v_error.get_type() == Variant::STRING) {
+		String error_str = v_error;
+		ERR_PRINT(vformat("Camera error from JS: %s", error_str));
+		return;
+	}
+
+	Variant v_devices = json_dict.get(KEY_CAMERAS, Variant());
+	if (v_devices.get_type() != Variant::ARRAY) {
+		ERR_PRINT("Camera error: 'cameras' is not an array or missing.");
+		return;
+	}
+
+	Array devices_array = v_devices;
+	Vector<CameraInfo> camera_info;
+	for (int i = 0; i < devices_array.size(); i++) {
+		Variant device_variant = devices_array.get(i);
+		if (device_variant.get_type() != Variant::DICTIONARY) {
+			continue;
+		}
+
+		Dictionary device_dict = device_variant;
+		if (!device_dict.has_all(_camera_info_key)) {
+			WARN_PRINT("Camera info entry missing required keys (index, id, label).");
+			continue;
+		}
+
+		CameraInfo info;
+		info.index = device_dict[KEY_INDEX];
+		info.device_id = device_dict[KEY_ID];
+		info.label = device_dict[KEY_LABEL];
+
+		// Parse formats array.
+		Variant v_formats = device_dict.get(KEY_FORMATS, Variant());
+		if (v_formats.get_type() == Variant::ARRAY) {
+			Array formats_array = v_formats;
+			for (int j = 0; j < formats_array.size(); j++) {
+				Variant format_variant = formats_array.get(j);
+				if (format_variant.get_type() != Variant::DICTIONARY) {
+					continue;
+				}
+
+				Dictionary format_dict = format_variant;
+				if (!format_dict.has(KEY_WIDTH) || !format_dict.has(KEY_HEIGHT)) {
+					continue;
+				}
+
+				int width = _get_int_value(format_dict.get(KEY_WIDTH, Variant()));
+				int height = _get_int_value(format_dict.get(KEY_HEIGHT, Variant()));
+				int frame_rate = _get_int_value(format_dict.get(KEY_FRAME_RATE, Variant()));
+
+				if (width > 0 && height > 0) {
+					FormatInfo format_info;
+					format_info.width = width;
+					format_info.height = height;
+					format_info.frame_rate = frame_rate;
+					info.formats.push_back(format_info);
+				}
+			}
+		}
+
+		if (info.formats.is_empty()) {
+			WARN_PRINT("Camera info entry has no valid formats.");
+		}
+
+		camera_info.push_back(info);
+	}
+
+	CameraDriverWebGetCamerasCallback on_get_cameras_callback = reinterpret_cast<CameraDriverWebGetCamerasCallback>(callback);
+	on_get_cameras_callback(context, camera_info);
+}
+
+void CameraDriverWeb::get_cameras(void *p_context, CameraDriverWebGetCamerasCallback p_callback) {
+	godot_js_camera_get_cameras(p_context, (void *)p_callback, &_on_get_cameras_callback);
+}
+
+void CameraDriverWeb::get_pixel_data(void *p_context, const String &p_device_id, const int p_width, const int p_height, void (*p_callback)(void *, const uint8_t *, const int, const int, const int, const int, const char *), void (*p_denied_callback)(void *)) {
+	godot_js_camera_get_pixel_data(p_context, p_device_id.utf8().get_data(), p_width, p_height, p_callback, p_denied_callback);
+}
+
+void CameraDriverWeb::stop_stream(const String &device_id) {
+	godot_js_camera_stop_stream(device_id.utf8().get_data());
+}
+
+CameraDriverWeb::CameraDriverWeb() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "CameraDriverWeb singleton already exists.");
+	_camera_info_key.push_back(KEY_INDEX);
+	_camera_info_key.push_back(KEY_ID);
+	_camera_info_key.push_back(KEY_LABEL);
+	singleton = this;
+}
+
+CameraDriverWeb::~CameraDriverWeb() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -66,7 +66,7 @@ int CameraDriverWeb::_get_int_value(const Variant &p_val) {
 }
 
 void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, const char *json_ptr) {
-	// Always call the user callback — even on error — so callers can clear any
+	// Always call the user callback, even on error, so callers can clear any
 	// in-progress flags (e.g. CameraWeb::activating) regardless of outcome.
 	CameraDriverWebGetCamerasCallback on_get_cameras_callback =
 			reinterpret_cast<CameraDriverWebGetCamerasCallback>(callback);

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -173,6 +173,8 @@ void CameraDriverWeb::stop_stream(const String &device_id) {
 
 CameraDriverWeb::CameraDriverWeb() {
 	ERR_FAIL_COND_MSG(singleton != nullptr, "CameraDriverWeb singleton already exists.");
+	// Clear before push_back in case the singleton is recreated (static Array persists).
+	_camera_info_key.clear();
 	_camera_info_key.push_back(KEY_INDEX);
 	_camera_info_key.push_back(KEY_ID);
 	_camera_info_key.push_back(KEY_LABEL);

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -167,8 +167,8 @@ void CameraDriverWeb::get_pixel_data(void *p_context, const String &p_device_id,
 	godot_js_camera_get_pixel_data(p_context, p_device_id.utf8().get_data(), p_width, p_height, p_callback, p_denied_callback);
 }
 
-void CameraDriverWeb::stop_stream(const String &device_id) {
-	godot_js_camera_stop_stream(device_id.utf8().get_data());
+void CameraDriverWeb::stop_stream(const String &p_device_id) {
+	godot_js_camera_stop_stream(p_device_id.utf8().get_data());
 }
 
 CameraDriverWeb::CameraDriverWeb() {

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -116,7 +116,7 @@ void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, co
 		}
 
 		CameraInfo info;
-		info.index = device_dict[KEY_INDEX];
+		info.index = _get_int_value(device_dict[KEY_INDEX]);
 		info.device_id = device_dict[KEY_ID];
 		info.label = device_dict[KEY_LABEL];
 

--- a/platform/web/camera_driver_web.h
+++ b/platform/web/camera_driver_web.h
@@ -47,7 +47,7 @@ public:
 	static CameraDriverWeb *get_singleton();
 	void get_cameras(void *p_context, CameraDriverWebGetCamerasCallback p_callback);
 	void get_pixel_data(void *p_context, const String &p_device_id, const int p_width, const int p_height, void (*p_callback)(void *, const uint8_t *, const int, const int, const int, const int, const char *), void (*p_denied_callback)(void *));
-	void stop_stream(const String &device_id = String());
+	void stop_stream(const String &p_device_id = String());
 
 	CameraDriverWeb();
 	~CameraDriverWeb();

--- a/platform/web/camera_driver_web.h
+++ b/platform/web/camera_driver_web.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  camera_driver_web.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,40 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#if defined(LINUXBSD_ENABLED)
-#include "camera_linux.h"
-#endif
-#if defined(WINDOWS_ENABLED)
-#include "camera_win.h"
-#endif
-#if defined(MACOS_ENABLED)
-#include "camera_apple.h"
-#endif
-#if defined(ANDROID_ENABLED)
-#include "camera_android.h"
-#endif
-#if defined(WEB_ENABLED)
-#include "camera_web.h"
-#endif
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
+#include "core/variant/array.h"
 
-void initialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+struct FormatInfo {
+	int width;
+	int height;
+	int frame_rate;
+};
 
-#if defined(LINUXBSD_ENABLED)
-	CameraServer::make_default<CameraLinux>();
-#endif
-#if defined(WINDOWS_ENABLED)
-	CameraServer::make_default<CameraWindows>();
-#endif
-#if defined(MACOS_ENABLED)
-	CameraServer::make_default<CameraApple>();
-#endif
-#if defined(ANDROID_ENABLED)
-	CameraServer::make_default<CameraAndroid>();
-#endif
-#if defined(WEB_ENABLED)
-	CameraServer::make_default<CameraWeb>();
-#endif
-}
+struct CameraInfo {
+	int index;
+	String device_id;
+	String label;
+	Vector<FormatInfo> formats;
+};
 
-void uninitialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-}
+using CameraDriverWebGetCamerasCallback = void (*)(void *p_context, const Vector<CameraInfo> &p_camera_info);
+
+class CameraDriverWeb {
+private:
+	static CameraDriverWeb *singleton;
+	static Array _camera_info_key;
+	static int _get_int_value(const Variant &p_val);
+	static void _on_get_cameras_callback(void *context, void *callback, const char *json_ptr);
+
+public:
+	static CameraDriverWeb *get_singleton();
+	void get_cameras(void *p_context, CameraDriverWebGetCamerasCallback p_callback);
+	void get_pixel_data(void *p_context, const String &p_device_id, const int p_width, const int p_height, void (*p_callback)(void *, const uint8_t *, const int, const int, const int, const int, const char *), void (*p_denied_callback)(void *));
+	void stop_stream(const String &device_id = String());
+
+	CameraDriverWeb();
+	~CameraDriverWeb();
+};

--- a/platform/web/camera_driver_web.h
+++ b/platform/web/camera_driver_web.h
@@ -30,22 +30,9 @@
 
 #pragma once
 
-#include "core/string/ustring.h"
-#include "core/templates/vector.h"
+#include "camera_types_web.h"
+
 #include "core/variant/array.h"
-
-struct FormatInfo {
-	int width;
-	int height;
-	int frame_rate;
-};
-
-struct CameraInfo {
-	int index;
-	String device_id;
-	String label;
-	Vector<FormatInfo> formats;
-};
 
 using CameraDriverWebGetCamerasCallback = void (*)(void *p_context, const Vector<CameraInfo> &p_camera_info);
 

--- a/platform/web/camera_types_web.h
+++ b/platform/web/camera_types_web.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  camera_web.h                                                          */
+/*  camera_types_web.h                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,48 +30,22 @@
 
 #pragma once
 
-#include "servers/camera/camera_feed.h"
-#include "servers/camera/camera_server.h"
+// Shared data types used by both the Web camera driver (platform/web) and the
+// camera module (modules/camera). Kept in a dedicated header so the module
+// does not need to include the full camera driver header.
 
-// Shared camera data types — kept in a platform/web-level header so this
-// module does not need to include the full CameraDriverWeb driver header.
-#include "platform/web/camera_types_web.h"
+#include "core/string/ustring.h"
+#include "core/templates/vector.h"
 
-class CameraDriverWeb;
-
-class CameraFeedWeb : public CameraFeed {
-	GDSOFTCLASS(CameraFeedWeb, CameraFeed);
-
-	String device_id;
-	Ref<Image> image;
-	Vector<uint8_t> data;
-
-	static void _on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_facing_mode, const char *p_error);
-	static void _on_denied_callback(void *p_context);
-
-public:
-	bool activate_feed() override;
-	void deactivate_feed() override;
-	bool set_format(int p_index, const Dictionary &p_parameters) override;
-	Array get_formats() const override;
-	FeedFormat get_format() const override;
-	String get_device_id() const { return device_id; }
-
-	CameraFeedWeb(const CameraInfo &info);
-	~CameraFeedWeb();
+struct FormatInfo {
+	int width;
+	int height;
+	int frame_rate;
 };
 
-class CameraWeb : public CameraServer {
-	GDSOFTCLASS(CameraWeb, CameraServer);
-
-	CameraDriverWeb *driver = nullptr;
-	SafeFlag activating;
-	void _cleanup();
-	void _update_feeds();
-	static void _on_get_cameras_callback(void *p_context, const Vector<CameraInfo> &p_camera_info);
-
-public:
-	void set_monitoring_feeds(bool p_monitoring_feeds) override;
-
-	~CameraWeb();
+struct CameraInfo {
+	int index;
+	String device_id;
+	String label;
+	Vector<FormatInfo> formats;
 };

--- a/platform/web/godot_camera.h
+++ b/platform/web/godot_camera.h
@@ -51,7 +51,7 @@ extern void godot_js_camera_get_pixel_data(
 		void (*p_callback)(void *p_context, const uint8_t *p_data, const int p_size, const int p_width, const int p_height, const int p_facing_mode, const char *p_error),
 		void (*p_denied_callback)(void *p_context));
 
-extern void godot_js_camera_stop_stream(const char *p_device_id = nullptr);
+extern void godot_js_camera_stop_stream(const char *p_device_id);
 
 #ifdef __cplusplus
 }

--- a/platform/web/godot_camera.h
+++ b/platform/web/godot_camera.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  godot_camera.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,31 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#if defined(LINUXBSD_ENABLED)
-#include "camera_linux.h"
-#endif
-#if defined(WINDOWS_ENABLED)
-#include "camera_win.h"
-#endif
-#if defined(MACOS_ENABLED)
-#include "camera_apple.h"
-#endif
-#if defined(ANDROID_ENABLED)
-#include "camera_android.h"
-#endif
-#if defined(WEB_ENABLED)
-#include "camera_web.h"
+#include <emscripten.h>
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-void initialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+extern void godot_js_camera_get_cameras(
+		void *p_context,
+		void *p_callback,
+		void (*p_callback_ptr)(void *p_context, void *p_callback, const char *p_result));
 
-#if defined(LINUXBSD_ENABLED)
-	CameraServer::make_default<CameraLinux>();
-#endif
-#if defined(WINDOWS_ENABLED)
-	CameraServer::make_default<CameraWindows>();
-#endif
-#if defined(MACOS_ENABLED)
-	CameraServer::make_default<CameraApple>();
-#endif
-#if defined(ANDROID_ENABLED)
-	CameraServer::make_default<CameraAndroid>();
-#endif
-#if defined(WEB_ENABLED)
-	CameraServer::make_default<CameraWeb>();
-#endif
+extern void godot_js_camera_get_pixel_data(
+		void *p_context,
+		const char *p_device_id,
+		const int p_width,
+		const int p_height,
+		void (*p_callback)(void *p_context, const uint8_t *p_data, const int p_size, const int p_width, const int p_height, const int p_facing_mode, const char *p_error),
+		void (*p_denied_callback)(void *p_context));
+
+extern void godot_js_camera_stop_stream(const char *p_device_id = nullptr);
+
+#ifdef __cplusplus
 }
-
-void uninitialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-}
+#endif

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -1196,7 +1196,7 @@ self.onmessage = async function(event) {
 						}
 					}
 				} catch (error) {
-					GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, 0, error.message);
+					GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, error.message);
 					if (error && (error.name === 'SecurityError' || error.name === 'NotAllowedError')) {
 						deniedCallback(context);
 					}

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -87,6 +87,21 @@ const GodotCamera = {
 		 */
 		_cachedDataSize: 0,
 
+		/**
+		 * Copies pixel data into the cached Wasm heap buffer, reallocating if the size changed.
+		 * @param {Uint8Array} p_data - Pixel data to copy.
+		 */
+		_heapCopyPixelData(p_data) {
+			if (GodotCamera._cachedDataSize !== p_data.length) {
+				if (GodotCamera._cachedDataPtr) {
+					GodotRuntime.free(GodotCamera._cachedDataPtr);
+				}
+				GodotCamera._cachedDataPtr = GodotRuntime.malloc(p_data.length);
+				GodotCamera._cachedDataSize = p_data.length;
+			}
+			GodotRuntime.heapCopy(HEAPU8, p_data, GodotCamera._cachedDataPtr);
+		},
+
 		defaultMinimumCapabilities: {
 			'width': {
 				'min': 1,
@@ -479,15 +494,7 @@ self.onmessage = async function(event) {
 		handleWorkerFrameData: function (eventData, callback, context, worker) {
 			const { pixelData, width, height, facingMode } = eventData;
 
-			// Reuse cached Wasm heap buffer to avoid per-frame malloc/free.
-			if (GodotCamera._cachedDataSize !== pixelData.length) {
-				if (GodotCamera._cachedDataPtr) {
-					GodotRuntime.free(GodotCamera._cachedDataPtr);
-				}
-				GodotCamera._cachedDataPtr = GodotRuntime.malloc(pixelData.length);
-				GodotCamera._cachedDataSize = pixelData.length;
-			}
-			GodotRuntime.heapCopy(HEAPU8, pixelData, GodotCamera._cachedDataPtr);
+			GodotCamera._heapCopyPixelData(pixelData);
 
 			GodotCamera.sendGetPixelDataCallback(
 				callback,
@@ -576,15 +583,7 @@ self.onmessage = async function(event) {
 								format: 'RGBA',
 							});
 
-							// Reuse cached Wasm heap buffer to avoid per-frame malloc/free.
-							if (GodotCamera._cachedDataSize !== pixelBuffer.length) {
-								if (GodotCamera._cachedDataPtr) {
-									GodotRuntime.free(GodotCamera._cachedDataPtr);
-								}
-								GodotCamera._cachedDataPtr = GodotRuntime.malloc(pixelBuffer.length);
-								GodotCamera._cachedDataSize = pixelBuffer.length;
-							}
-							GodotRuntime.heapCopy(HEAPU8, pixelBuffer, GodotCamera._cachedDataPtr);
+							GodotCamera._heapCopyPixelData(pixelBuffer);
 
 							GodotCamera.sendGetPixelDataCallback(
 								callback,
@@ -823,15 +822,7 @@ self.onmessage = async function(event) {
 						const imageData = currentCamera.canvasContext.getImageData(0, 0, _width, _height);
 						const pixelData = imageData.data;
 
-						// Reuse cached Wasm heap buffer to avoid per-frame malloc/free.
-						if (GodotCamera._cachedDataSize !== pixelData.length) {
-							if (GodotCamera._cachedDataPtr) {
-								GodotRuntime.free(GodotCamera._cachedDataPtr);
-							}
-							GodotCamera._cachedDataPtr = GodotRuntime.malloc(pixelData.length);
-							GodotCamera._cachedDataSize = pixelData.length;
-						}
-						GodotRuntime.heapCopy(HEAPU8, pixelData, GodotCamera._cachedDataPtr);
+						GodotCamera._heapCopyPixelData(pixelData);
 
 						GodotCamera.sendGetPixelDataCallback(
 							callback,

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -1,0 +1,1180 @@
+/**************************************************************************/
+/*  library_godot_camera.js                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+/**
+ * @typedef {{
+ *   deviceId: string
+ *   label: string
+ *   index: number
+ * }} CameraInfo
+ *
+ * @typedef {{
+ *   video: HTMLVideoElement|null
+ *   canvas: (HTMLCanvasElement|OffscreenCanvas)|null
+ *   canvasContext: (CanvasRenderingContext2D|OffscreenCanvasRenderingContext2D)|null
+ *   stream: MediaStream|null
+ *   animationFrameId: number|null
+ *   permissionListener: Function|null
+ *   permissionStatus: PermissionStatus|null
+ *   trackProcessor: MediaStreamTrackProcessor|null
+ *   frameReader: ReadableStreamDefaultReader|null
+ *   worker: Worker|null
+ *   useWebCodecsWorker: boolean
+ *   useWebCodecs: boolean
+ *   useWorker: boolean
+ * }} CameraResource
+ */
+
+const GodotCamera = {
+	$GodotCamera__deps: ['$GodotRuntime', '$GodotConfig', '$GodotOS'],
+	$GodotCamera__postset: 'GodotOS.atexit(function(resolve, reject) { GodotCamera.cleanup(); resolve(); });',
+	$GodotCamera: {
+		/**
+		 * Map to manage resources for each camera.
+		 * @type {Map<string, CameraResource>}
+		 */
+		cameras: new Map(),
+
+		/**
+		 * Cached result of Web Worker support check.
+		 * @type {boolean|null}
+		 */
+		workerSupported: null,
+
+		/**
+		 * Blob URL for the camera worker script.
+		 * @type {string|null}
+		 */
+		workerBlobUrl: null,
+
+		defaultMinimumCapabilities: {
+			'width': {
+				'min': 1,
+				'max': 1280,
+			},
+			'height': {
+				'min': 1,
+				'max': 720,
+			},
+		},
+
+		/**
+		 * Common resolutions to check against camera capabilities.
+		 */
+		commonResolutions: [
+			{ width: 320, height: 240 }, // QVGA (4:3)
+			{ width: 352, height: 288 }, // CIF (4:3) - Video conferencing
+			{ width: 640, height: 480 }, // VGA (4:3)
+			{ width: 1024, height: 768 }, // XGA (4:3)
+			{ width: 1280, height: 720 }, // HD 720p (16:9)
+			{ width: 1280, height: 960 }, // SXGA- (4:3)
+			{ width: 1600, height: 1200 }, // UXGA (4:3)
+			{ width: 1920, height: 1080 }, // Full HD 1080p (16:9)
+			{ width: 2560, height: 1440 }, // QHD 1440p (16:9)
+			{ width: 3840, height: 2160 }, // 4K UHD 2160p (16:9)
+		],
+
+		/**
+		 * Gets supported formats based on capabilities.
+		 * @param {Object} capabilities MediaTrackCapabilities object
+		 * @returns {Array<{width: number, height: number, frameRate: number}>} Supported resolutions with frame rate
+		 */
+		getSupportedFormats: function (capabilities) {
+			const widthRange = capabilities.width || this.defaultMinimumCapabilities.width;
+			const heightRange = capabilities.height || this.defaultMinimumCapabilities.height;
+			const frameRateRange = capabilities.frameRate || { min: 1, max: 30 };
+			const maxFrameRate = frameRateRange.max || 30;
+
+			return this.commonResolutions
+				.filter((res) => res.width >= (widthRange.min || 1)
+					&& res.width <= (widthRange.max || 9999)
+					&& res.height >= (heightRange.min || 1)
+					&& res.height <= (heightRange.max || 9999))
+				.map((res) => ({
+					width: res.width,
+					height: res.height,
+					frameRate: maxFrameRate,
+				}));
+		},
+
+		/**
+		 * Checks if WebCodecs API is supported for camera capture.
+		 * @returns {boolean} True if MediaStreamTrackProcessor and VideoFrame are available
+		 */
+		isWebCodecsSupported: function () {
+			return 'MediaStreamTrackProcessor' in window && 'VideoFrame' in window;
+		},
+
+		/**
+		 * Checks if Web Worker for camera frame processing is supported.
+		 * Requires Worker, OffscreenCanvas, and createImageBitmap support.
+		 * @returns {boolean} True if worker-based capture is supported
+		 */
+		isWorkerSupported: function () {
+			if (this.workerSupported !== null) {
+				return this.workerSupported;
+			}
+
+			try {
+				// Check for Worker support
+				if (typeof Worker === 'undefined') {
+					this.workerSupported = false;
+					return false;
+				}
+
+				// Check for OffscreenCanvas support (required in worker)
+				if (typeof OffscreenCanvas === 'undefined') {
+					this.workerSupported = false;
+					return false;
+				}
+
+				// Check for createImageBitmap support (required for transferring frames)
+				if (typeof createImageBitmap === 'undefined') {
+					this.workerSupported = false;
+					return false;
+				}
+
+				this.workerSupported = true;
+				// Web Worker supported.
+			} catch (e) {
+				// Web Worker not supported.
+				this.workerSupported = false;
+			}
+
+			return this.workerSupported;
+		},
+
+		/**
+		 * Creates or returns the Blob URL for the camera worker script.
+		 * The worker is embedded as inline code to avoid external file dependencies.
+		 * @returns {string|null} Blob URL for the worker, or null if creation fails
+		 */
+		getWorkerBlobUrl: function () {
+			if (this.workerBlobUrl) {
+				return this.workerBlobUrl;
+			}
+
+			// Worker code embedded as a string.
+			// Supports both VideoFrame (WebCodecs) and ImageBitmap (Canvas 2D) processing.
+			const workerCode = `
+// Worker state
+let canvas = null;
+let canvasContext = null;
+let width = 0;
+let height = 0;
+let isCapturing = false;
+
+// Process ImageBitmap using Canvas 2D (fallback method)
+function processImageBitmap(imageBitmap) {
+	const frameWidth = imageBitmap.width;
+	const frameHeight = imageBitmap.height;
+
+	if (canvas.width !== frameWidth || canvas.height !== frameHeight) {
+		canvas.width = frameWidth;
+		canvas.height = frameHeight;
+		width = frameWidth;
+		height = frameHeight;
+		canvasContext = canvas.getContext('2d', { willReadFrequently: true });
+	}
+
+	canvasContext.drawImage(imageBitmap, 0, 0, width, height);
+	const imageData = canvasContext.getImageData(0, 0, width, height);
+	imageBitmap.close();
+
+	return {
+		pixelData: imageData.data,
+		width: width,
+		height: height,
+	};
+}
+
+// Process VideoFrame using WebCodecs copyTo (most efficient)
+async function processVideoFrame(videoFrame) {
+	const frameWidth = videoFrame.displayWidth;
+	const frameHeight = videoFrame.displayHeight;
+	const bufferSize = frameWidth * frameHeight * 4;
+	const pixelBuffer = new Uint8Array(bufferSize);
+
+	try {
+		await videoFrame.copyTo(pixelBuffer, {
+			rect: { x: 0, y: 0, width: frameWidth, height: frameHeight },
+			layout: [{ offset: 0, stride: frameWidth * 4 }],
+			format: 'RGBA',
+		});
+
+		return {
+			pixelData: pixelBuffer,
+			width: frameWidth,
+			height: frameHeight,
+		};
+	} finally {
+		videoFrame.close();
+	}
+}
+
+self.onmessage = async function(event) {
+	const { type, data } = event.data;
+
+	switch (type) {
+	case 'init':
+		canvas = new OffscreenCanvas(data.width || 640, data.height || 480);
+		width = data.width || 640;
+		height = data.height || 480;
+		canvasContext = canvas.getContext('2d', { willReadFrequently: true });
+		isCapturing = true;
+		self.postMessage({ type: 'initialized' });
+		break;
+
+	case 'videoFrame':
+		// WebCodecs VideoFrame processing
+		if (!isCapturing) {
+			if (data.videoFrame) {
+				data.videoFrame.close();
+			}
+			return;
+		}
+
+		try {
+			const result = await processVideoFrame(data.videoFrame);
+			self.postMessage(
+				{
+					type: 'frameData',
+					pixelData: result.pixelData,
+					width: result.width,
+					height: result.height,
+					facingMode: data.facingMode,
+				},
+				[result.pixelData.buffer]
+			);
+		} catch (error) {
+			self.postMessage({
+				type: 'error',
+				message: error.message,
+			});
+		}
+		break;
+
+	case 'frame':
+		// Canvas 2D ImageBitmap processing (fallback)
+		if (!isCapturing || !canvas) {
+			if (data.imageBitmap) {
+				data.imageBitmap.close();
+			}
+			return;
+		}
+
+		try {
+			const result = processImageBitmap(data.imageBitmap);
+			self.postMessage(
+				{
+					type: 'frameData',
+					pixelData: result.pixelData,
+					width: result.width,
+					height: result.height,
+					facingMode: data.facingMode,
+				},
+				[result.pixelData.buffer]
+			);
+		} catch (error) {
+			self.postMessage({
+				type: 'error',
+				message: error.message,
+			});
+		}
+		break;
+
+	case 'stop':
+		isCapturing = false;
+		canvas = null;
+		canvasContext = null;
+		self.postMessage({ type: 'stopped' });
+		break;
+
+	default:
+		console.warn('Unknown message type:', type);
+	}
+};
+`;
+
+			try {
+				const blob = new Blob([workerCode], { type: 'application/javascript' });
+				this.workerBlobUrl = URL.createObjectURL(blob);
+				return this.workerBlobUrl;
+			} catch (e) {
+				GodotRuntime.print('Failed to create worker blob URL:', e.message);
+				return null;
+			}
+		},
+
+		/**
+		 * Ensures cameras Map is properly initialized.
+		 * @returns {Map<string, CameraResource>}
+		 */
+		ensureCamerasMap: function () {
+			if (!this.cameras || !(this.cameras instanceof Map)) {
+				this.cameras = new Map();
+			}
+			return this.cameras;
+		},
+
+		/**
+		 * Cleanup all camera resources.
+		 * @returns {void}
+		 */
+		cleanup: function () {
+			this.api.stop();
+
+			// Revoke worker blob URL to free memory.
+			if (this.workerBlobUrl) {
+				URL.revokeObjectURL(this.workerBlobUrl);
+				this.workerBlobUrl = null;
+			}
+		},
+
+		/**
+		 * Sends a JSON result to the callback function.
+		 * @param {Function} callback Callback function pointer
+		 * @param {number} callbackPtr Context value to pass to callback
+		 * @param {number} context Context value to pass to callback
+		 * @param {Object} result Result object to stringify
+		 * @returns {void}
+		 */
+		sendCamerasCallbackResult: function (callback, callbackPtr, context, result) {
+			const jsonStr = JSON.stringify(result);
+			const strPtr = GodotRuntime.allocString(jsonStr);
+			callback(context, callbackPtr, strPtr);
+			GodotRuntime.free(strPtr);
+		},
+
+		/**
+		 * Sends pixel data or error to the callback function.
+		 * @param {Function} callback Callback function pointer
+		 * @param {number} context Context value to pass to callback
+		 * @param {number} dataPtr Pointer to pixel data
+		 * @param {number} dataLen Length of pixel data
+		 * @param {number} width Image width
+		 * @param {number} height Image height
+		 * @param {number} facingMode Camera facing mode (0=unknown, 1=user/front, 2=environment/back)
+		 * @param {string|null} errorMsg Error message if any
+		 * @returns {void}
+		 */
+		sendGetPixelDataCallback: function (callback, context, dataPtr, dataLen, width, height, facingMode, errorMsg) {
+			const errorMsgPtr = errorMsg ? GodotRuntime.allocString(errorMsg) : 0;
+			callback(context, dataPtr, dataLen, width, height, facingMode, errorMsgPtr);
+			if (errorMsgPtr) {
+				GodotRuntime.free(errorMsgPtr);
+			}
+		},
+
+		/**
+		 * Handles a 'frameData' message from a worker and forwards it to the C++ callback.
+		 * @param {Object} eventData Worker message event.data
+		 * @param {Function} callback Callback function pointer
+		 * @param {number} context Context value to pass to callback
+		 * @returns {void}
+		 */
+		handleWorkerFrameData: function (eventData, callback, context) {
+			const { pixelData, width, height, facingMode } = eventData;
+			const dataPtr = GodotRuntime.malloc(pixelData.length);
+			GodotRuntime.heapCopy(HEAPU8, pixelData, dataPtr);
+
+			GodotCamera.sendGetPixelDataCallback(
+				callback,
+				context,
+				dataPtr,
+				pixelData.length,
+				width,
+				height,
+				facingMode,
+				null
+			);
+
+			GodotRuntime.free(dataPtr);
+		},
+
+		/**
+		 * Converts facingMode string to numeric value.
+		 * @param {MediaStream|null} stream Media stream to get facing mode from
+		 * @returns {number} 0=unknown, 1=user/front, 2=environment/back
+		 */
+		getFacingMode: function (stream) {
+			if (!stream) {
+				return 0;
+			}
+			const [videoTrack] = stream.getVideoTracks();
+			if (!videoTrack) {
+				return 0;
+			}
+			const settings = videoTrack.getSettings();
+			switch (settings.facingMode) {
+			case 'user':
+				return 1; // Front camera
+			case 'environment':
+				return 2; // Back camera
+			default:
+				return 0; // Unknown
+			}
+		},
+
+		/**
+		 * Sets up WebCodecs-based frame capture using MediaStreamTrackProcessor.
+		 * @param {CameraResource} camera Camera resource
+		 * @param {string} cameraId Camera identifier
+		 * @param {Function} callback Callback function for frame data
+		 * @param {number} context Context value to pass to callback
+		 * @param {Function} deniedCallback Callback for permission denied
+		 * @returns {void}
+		 */
+		setupWebCodecsCapture: function (camera, cameraId, callback, context, deniedCallback) {
+			const [videoTrack] = camera.stream.getVideoTracks();
+
+			camera.trackProcessor = new MediaStreamTrackProcessor({ track: videoTrack });
+			camera.frameReader = camera.trackProcessor.readable.getReader();
+
+			const processFrames = async () => {
+				const cameras = GodotCamera.ensureCamerasMap();
+				try {
+					while (true) {
+						const currentCamera = cameras.get(cameraId);
+						if (!currentCamera || !currentCamera.useWebCodecs) {
+							break;
+						}
+
+						// eslint-disable-next-line no-await-in-loop
+						const { done, value: videoFrame } = await currentCamera.frameReader.read();
+						if (done) {
+							break;
+						}
+
+						try {
+							const width = videoFrame.displayWidth;
+							const height = videoFrame.displayHeight;
+							const bufferSize = width * height * 4;
+							const pixelBuffer = new Uint8Array(bufferSize);
+
+							// eslint-disable-next-line no-await-in-loop
+							await videoFrame.copyTo(pixelBuffer, {
+								rect: { x: 0, y: 0, width, height },
+								layout: [{ offset: 0, stride: width * 4 }],
+								format: 'RGBA',
+							});
+
+							const dataPtr = GodotRuntime.malloc(pixelBuffer.length);
+							GodotRuntime.heapCopy(HEAPU8, pixelBuffer, dataPtr);
+
+							const facingMode = GodotCamera.getFacingMode(currentCamera.stream);
+
+							GodotCamera.sendGetPixelDataCallback(
+								callback,
+								context,
+								dataPtr,
+								pixelBuffer.length,
+								width,
+								height,
+								facingMode,
+								null
+							);
+
+							GodotRuntime.free(dataPtr);
+						} finally {
+							videoFrame.close();
+						}
+					}
+				} catch (error) {
+					GodotRuntime.print('WebCodecs error, falling back to Canvas 2D:', error.message);
+					const currentCamera = cameras.get(cameraId);
+					if (currentCamera) {
+						// Clean up WebCodecs resources before fallback.
+						if (currentCamera.frameReader) {
+							currentCamera.frameReader.cancel().catch(() => {});
+							currentCamera.frameReader = null;
+						}
+						currentCamera.trackProcessor = null;
+						currentCamera.useWebCodecs = false;
+
+						// Fall back to Worker-based Canvas 2D if supported, else main thread.
+						if (GodotCamera.isWorkerSupported()) {
+							currentCamera.useWorker = true;
+							GodotCamera.setupCanvas2DWorkerCapture(currentCamera, cameraId, callback, context, deniedCallback);
+						} else {
+							GodotCamera.setupCanvas2DCapture(currentCamera, cameraId, callback, context, deniedCallback);
+						}
+					}
+				}
+			};
+
+			processFrames();
+		},
+
+		/**
+		 * Sets up WebCodecs + Worker frame capture.
+		 * Uses MediaStreamTrackProcessor to get VideoFrame, transfers to Worker for copyTo().
+		 * This is the most efficient method as it offloads processing to a worker thread.
+		 * @param {CameraResource} camera Camera resource
+		 * @param {string} cameraId Camera identifier
+		 * @param {Function} callback Callback function for frame data
+		 * @param {number} context Context value to pass to callback
+		 * @param {Function} deniedCallback Callback for permission denied
+		 * @returns {void}
+		 */
+		setupWebCodecsWorkerCapture: function (camera, cameraId, callback, context, deniedCallback) {
+			const workerUrl = this.getWorkerBlobUrl();
+			if (!workerUrl) {
+				GodotRuntime.print('Failed to create worker, falling back to WebCodecs main thread');
+				this.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
+				return;
+			}
+
+			try {
+				camera.worker = new Worker(workerUrl);
+			} catch (e) {
+				GodotRuntime.print('Failed to create worker:', e.message);
+				this.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
+				return;
+			}
+
+			// Set up MediaStreamTrackProcessor
+			const [videoTrack] = camera.stream.getVideoTracks();
+			camera.trackProcessor = new MediaStreamTrackProcessor({ track: videoTrack });
+			camera.frameReader = camera.trackProcessor.readable.getReader();
+
+			// Handle messages from worker
+			camera.worker.onmessage = (event) => {
+				const { type } = event.data;
+
+				switch (type) {
+				case 'frameData':
+					GodotCamera.handleWorkerFrameData(event.data, callback, context);
+					break;
+
+				case 'error':
+					GodotRuntime.print('Worker error:', event.data.message);
+					// Fall back to Worker Canvas 2D on error
+					camera.useWebCodecsWorker = false;
+					if (camera.frameReader) {
+						camera.frameReader.cancel().catch(() => {});
+						camera.frameReader = null;
+					}
+					camera.trackProcessor = null;
+					// Keep the worker for Canvas 2D fallback
+					camera.useWorker = true;
+					GodotCamera.setupCanvas2DWorkerCapture(camera, cameraId, callback, context, deniedCallback);
+					break;
+
+				default:
+					break;
+				}
+			};
+
+			camera.worker.onerror = (error) => {
+				GodotRuntime.print('Worker error event:', error.message);
+				camera.useWebCodecsWorker = false;
+				if (camera.frameReader) {
+					camera.frameReader.cancel().catch(() => {});
+					camera.frameReader = null;
+				}
+				camera.trackProcessor = null;
+				if (camera.worker) {
+					camera.worker.terminate();
+					camera.worker = null;
+				}
+				// Fall back to WebCodecs main thread
+				camera.useWebCodecs = true;
+				GodotCamera.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
+			};
+
+			// Initialize the worker
+			camera.worker.postMessage({
+				type: 'init',
+				data: { width: camera.video.videoWidth || 640, height: camera.video.videoHeight || 480 },
+			});
+
+			// Start the frame reading loop
+			const processFrames = async () => {
+				const cameras = GodotCamera.ensureCamerasMap();
+				try {
+					while (true) {
+						const currentCamera = cameras.get(cameraId);
+						if (!currentCamera || !currentCamera.useWebCodecsWorker || !currentCamera.worker) {
+							break;
+						}
+
+						// eslint-disable-next-line no-await-in-loop
+						const { done, value: videoFrame } = await currentCamera.frameReader.read();
+						if (done) {
+							break;
+						}
+
+						const facingMode = GodotCamera.getFacingMode(currentCamera.stream);
+
+						// Transfer VideoFrame to worker
+						currentCamera.worker.postMessage(
+							{
+								type: 'videoFrame',
+								data: {
+									videoFrame,
+									facingMode,
+								},
+							},
+							[videoFrame]
+						);
+					}
+				} catch (error) {
+					GodotRuntime.print('WebCodecs Worker error, falling back:', error.message);
+					const currentCamera = cameras.get(cameraId);
+					if (currentCamera && currentCamera.useWebCodecsWorker) {
+						currentCamera.useWebCodecsWorker = false;
+						if (currentCamera.frameReader) {
+							currentCamera.frameReader.cancel().catch(() => {});
+							currentCamera.frameReader = null;
+						}
+						currentCamera.trackProcessor = null;
+
+						// Fall back to Worker Canvas 2D
+						if (currentCamera.worker) {
+							currentCamera.useWorker = true;
+							GodotCamera.setupCanvas2DWorkerCapture(currentCamera, cameraId, callback, context, deniedCallback);
+						} else {
+							// Fall back to WebCodecs main thread
+							currentCamera.useWebCodecs = true;
+							GodotCamera.setupWebCodecsCapture(currentCamera, cameraId, callback, context, deniedCallback);
+						}
+					}
+				}
+			};
+
+			processFrames();
+		},
+
+		/**
+		 * Sets up Canvas 2D-based frame capture (fallback method).
+		 * @param {CameraResource} camera Camera resource
+		 * @param {string} cameraId Camera identifier
+		 * @param {Function} callback Callback function for frame data
+		 * @param {number} context Context value to pass to callback
+		 * @param {Function} deniedCallback Callback for permission denied
+		 * @returns {void}
+		 */
+		setupCanvas2DCapture: function (camera, cameraId, callback, context, deniedCallback) {
+			if (camera.animationFrameId) {
+				cancelAnimationFrame(camera.animationFrameId);
+			}
+
+			const captureFrame = () => {
+				const cameras = GodotCamera.ensureCamerasMap();
+				const currentCamera = cameras.get(cameraId);
+				if (!currentCamera) {
+					return;
+				}
+
+				const { video, stream } = currentCamera;
+
+				if (!stream || !stream.active) {
+					GodotRuntime.print('Stream is not active, stopping');
+					GodotCamera.api.stop(cameraId);
+					return;
+				}
+
+				if (video.readyState === video.HAVE_ENOUGH_DATA) {
+					const _width = video.videoWidth;
+					const _height = video.videoHeight;
+
+					// Ensure canvas matches current video dimensions.
+					if (!currentCamera.canvas) {
+						if (typeof OffscreenCanvas !== 'undefined') {
+							currentCamera.canvas = new OffscreenCanvas(_width, _height);
+						} else {
+							currentCamera.canvas = document.createElement('canvas');
+							currentCamera.canvas.style.display = 'none';
+							document.body.appendChild(currentCamera.canvas);
+						}
+					}
+
+					if (currentCamera.canvas.width !== _width || currentCamera.canvas.height !== _height) {
+						currentCamera.canvas.width = _width;
+						currentCamera.canvas.height = _height;
+						currentCamera.canvasContext = null;
+					}
+
+					if (!currentCamera.canvasContext) {
+						currentCamera.canvasContext = currentCamera.canvas.getContext('2d', { willReadFrequently: true });
+					}
+
+					try {
+						currentCamera.canvasContext.drawImage(video, 0, 0, _width, _height);
+						const imageData = currentCamera.canvasContext.getImageData(0, 0, _width, _height);
+						const pixelData = imageData.data;
+
+						const dataPtr = GodotRuntime.malloc(pixelData.length);
+						GodotRuntime.heapCopy(HEAPU8, pixelData, dataPtr);
+
+						const facingMode = GodotCamera.getFacingMode(stream);
+
+						GodotCamera.sendGetPixelDataCallback(
+							callback,
+							context,
+							dataPtr,
+							pixelData.length,
+							_width,
+							_height,
+							facingMode,
+							null
+						);
+
+						GodotRuntime.free(dataPtr);
+					} catch (error) {
+						GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, error.message);
+
+						if (error.name === 'SecurityError' || error.name === 'NotAllowedError') {
+							GodotRuntime.print('Security error, stopping stream:', error);
+							GodotCamera.api.stop(cameraId);
+							deniedCallback(context);
+						}
+						return;
+					}
+				}
+
+				currentCamera.animationFrameId = requestAnimationFrame(captureFrame);
+			};
+
+			camera.animationFrameId = requestAnimationFrame(captureFrame);
+		},
+
+		/**
+		 * Sets up Web Worker-based Canvas 2D frame capture.
+		 * Offloads drawImage and getImageData to a worker thread.
+		 * @param {CameraResource} camera Camera resource
+		 * @param {string} cameraId Camera identifier
+		 * @param {Function} callback Callback function for frame data
+		 * @param {number} context Context value to pass to callback
+		 * @param {Function} deniedCallback Callback for permission denied
+		 * @returns {void}
+		 */
+		setupCanvas2DWorkerCapture: function (camera, cameraId, callback, context, deniedCallback) {
+			const workerUrl = this.getWorkerBlobUrl();
+			if (!workerUrl) {
+				GodotRuntime.print('Failed to create worker, falling back to main thread Canvas 2D');
+				camera.useWorker = false;
+				this.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+				return;
+			}
+
+			try {
+				camera.worker = new Worker(workerUrl);
+			} catch (e) {
+				GodotRuntime.print('Failed to create worker:', e.message);
+				camera.useWorker = false;
+				this.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+				return;
+			}
+
+			// Handle messages from worker.
+			camera.worker.onmessage = (event) => {
+				const { type } = event.data;
+
+				switch (type) {
+				case 'frameData':
+					GodotCamera.handleWorkerFrameData(event.data, callback, context);
+					break;
+
+				case 'error':
+					GodotRuntime.print('Worker error:', event.data.message);
+					// Fall back to main thread on error.
+					camera.useWorker = false;
+					if (camera.worker) {
+						camera.worker.terminate();
+						camera.worker = null;
+					}
+					GodotCamera.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+					break;
+
+				default:
+					break;
+				}
+			};
+
+			camera.worker.onerror = (error) => {
+				GodotRuntime.print('Worker error event:', error.message);
+				camera.useWorker = false;
+				if (camera.worker) {
+					camera.worker.terminate();
+					camera.worker = null;
+				}
+				GodotCamera.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+			};
+
+			// Initialize the worker with default dimensions (will be updated per frame).
+			camera.worker.postMessage({
+				type: 'init',
+				data: { width: camera.video.videoWidth || 640, height: camera.video.videoHeight || 480 },
+			});
+
+			// Start the frame capture loop.
+			const captureFrame = () => {
+				const cameras = GodotCamera.ensureCamerasMap();
+				const currentCamera = cameras.get(cameraId);
+				if (!currentCamera || !currentCamera.useWorker || !currentCamera.worker) {
+					return;
+				}
+
+				const { video, stream } = currentCamera;
+
+				if (!stream || !stream.active) {
+					GodotRuntime.print('Stream is not active, stopping');
+					GodotCamera.api.stop(cameraId);
+					return;
+				}
+
+				if (video.readyState === video.HAVE_ENOUGH_DATA) {
+					try {
+						// Create ImageBitmap from video (can be transferred to worker).
+						createImageBitmap(video).then((imageBitmap) => {
+							const cam = cameras.get(cameraId);
+							if (!cam || !cam.useWorker || !cam.worker) {
+								imageBitmap.close();
+								return;
+							}
+
+							const facingMode = GodotCamera.getFacingMode(cam.stream);
+
+							cam.worker.postMessage(
+								{
+									type: 'frame',
+									data: {
+										imageBitmap,
+										facingMode,
+									},
+								},
+								[imageBitmap]
+							);
+						}).catch((e) => {
+							GodotRuntime.print('createImageBitmap error:', e.message);
+						});
+					} catch (error) {
+						GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, error.message);
+
+						if (error.name === 'SecurityError' || error.name === 'NotAllowedError') {
+							GodotRuntime.print('Security error, stopping stream:', error);
+							GodotCamera.api.stop(cameraId);
+							deniedCallback(context);
+						}
+						return;
+					}
+				}
+
+				currentCamera.animationFrameId = requestAnimationFrame(captureFrame);
+			};
+
+			camera.animationFrameId = requestAnimationFrame(captureFrame);
+		},
+
+		/**
+		 * Cleans up resources for a specific camera.
+		 * @param {CameraResource} camera Camera resource to cleanup
+		 * @returns {void}
+		 */
+		cleanupCamera: function (camera) {
+			// Clean up Web Worker resources.
+			if (camera.worker) {
+				camera.worker.postMessage({ type: 'stop' });
+				camera.worker.terminate();
+				camera.worker = null;
+			}
+
+			// Clean up WebCodecs resources.
+			if (camera.frameReader) {
+				camera.frameReader.cancel().catch(() => {});
+				camera.frameReader = null;
+			}
+			if (camera.trackProcessor) {
+				camera.trackProcessor = null;
+			}
+
+			if (camera.animationFrameId) {
+				cancelAnimationFrame(camera.animationFrameId);
+			}
+
+			if (camera.stream) {
+				camera.stream.getTracks().forEach((track) => track.stop());
+			}
+
+			if (camera.video && camera.video.parentNode) {
+				camera.video.parentNode.removeChild(camera.video);
+			}
+
+			if (camera.canvas && camera.canvas instanceof HTMLCanvasElement && camera.canvas.parentNode) {
+				camera.canvas.parentNode.removeChild(camera.canvas);
+			}
+
+			if (camera.permissionListener && camera.permissionStatus) {
+				camera.permissionStatus.removeEventListener('change', camera.permissionListener);
+				camera.permissionListener = null;
+				camera.permissionStatus = null;
+			}
+
+			// Null out references to help GC.
+			camera.animationFrameId = null;
+			camera.canvasContext = null;
+			camera.stream = null;
+			camera.video = null;
+			camera.canvas = null;
+			camera.useWebCodecsWorker = false;
+			camera.useWebCodecs = false;
+			camera.useWorker = false;
+		},
+
+		api: {
+			/**
+			 * Gets list of available cameras.
+			 * Calls callback with JSON containing array of camera info.
+			 * @param {number} context Context value to pass to callback
+			 * @param {number} callbackPtr1 Pointer to callback function
+			 * @param {number} callbackPtr2 Pointer to callback function
+			 * @returns {Promise<void>}
+			 */
+			getCameras: async function (context, callbackPtr1, callbackPtr2) {
+				const callback = GodotRuntime.get_func(callbackPtr2);
+				const result = { error: null, cameras: null };
+
+				try {
+					// Request camera access permission first.
+					const initialStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+					initialStream.getTracks().forEach((track) => track.stop());
+
+					const devices = await navigator.mediaDevices.enumerateDevices();
+					const videoDevices = devices.filter((device) => device.kind === 'videoinput');
+
+					// Get capabilities for each camera device.
+					// Use InputDeviceInfo.getCapabilities() when available (Chrome/Edge 109+)
+					// to avoid opening a stream per device (which causes LED flicker and is slow).
+					// Fall back to default capabilities on browsers without support (Firefox, Safari).
+					result.cameras = videoDevices.map((device, index) => {
+						let formats;
+						if (typeof device.getCapabilities === 'function') {
+							const capabilities = device.getCapabilities();
+							formats = GodotCamera.getSupportedFormats(capabilities);
+						} else {
+							formats = GodotCamera.getSupportedFormats(GodotCamera.defaultMinimumCapabilities);
+						}
+
+						return {
+							index,
+							id: device.deviceId,
+							label: device.label || `Camera ${index}`,
+							formats,
+						};
+					});
+				} catch (error) {
+					result.error = error.message;
+				}
+
+				GodotCamera.sendCamerasCallbackResult(callback, callbackPtr1, context, result);
+			},
+
+			/**
+			 * Starts capturing pixel data from camera.
+			 * Continuously calls callback with pixel data.
+			 * @param {number} context Context value to pass to callback
+			 * @param {string|null} deviceId Camera device ID
+			 * @param {number} width Desired capture width
+			 * @param {number} height Desired capture height
+			 * @param {number} callbackPtr Pointer to callback function
+			 * @param {number} deniedCallbackPtr Pointer to callback function
+			 * @returns {Promise<void>}
+			 */
+			getPixelData: async function (context, deviceId, width, height, callbackPtr, deniedCallbackPtr) {
+				const callback = GodotRuntime.get_func(callbackPtr);
+				const deniedCallback = GodotRuntime.get_func(deniedCallbackPtr);
+				const cameraId = deviceId || 'default';
+
+				try {
+					const camerasMap = GodotCamera.ensureCamerasMap();
+					let camera = camerasMap.get(cameraId);
+					if (!camera) {
+						camera = {
+							video: null,
+							canvas: null,
+							canvasContext: null,
+							stream: null,
+							animationFrameId: null,
+							permissionListener: null,
+							permissionStatus: null,
+							trackProcessor: null,
+							frameReader: null,
+							worker: null,
+							useWebCodecsWorker: false,
+							useWebCodecs: false,
+							useWorker: false,
+						};
+						camerasMap.set(cameraId, camera);
+					}
+
+					if (!camera.stream) {
+						// Create video element (needed for Canvas 2D fallback).
+						camera.video = document.createElement('video');
+						camera.video.style.display = 'none';
+						camera.video.autoplay = true;
+						camera.video.playsInline = true;
+						document.body.appendChild(camera.video);
+
+						const constraints = {
+							video: {
+								deviceId: deviceId ? { exact: deviceId } : undefined,
+								width: { ideal: width },
+								height: { ideal: height },
+							},
+						};
+						// eslint-disable-next-line require-atomic-updates
+						camera.stream = await navigator.mediaDevices.getUserMedia(constraints);
+
+						const [videoTrack] = camera.stream.getVideoTracks();
+						videoTrack.addEventListener('ended', () => {
+							GodotCamera.api.stop(cameraId);
+						});
+
+						if (navigator.permissions && navigator.permissions.query) {
+							try {
+								const permissionStatus = await navigator.permissions.query({ name: 'camera' });
+								// eslint-disable-next-line require-atomic-updates
+								camera.permissionStatus = permissionStatus;
+								camera.permissionListener = () => {
+									if (permissionStatus.state === 'denied') {
+										GodotRuntime.print('Camera permission denied, stopping stream');
+										if (camera.permissionListener) {
+											permissionStatus.removeEventListener('change', camera.permissionListener);
+										}
+										GodotCamera.api.stop(cameraId);
+										deniedCallback(context);
+									}
+								};
+								permissionStatus.addEventListener('change', camera.permissionListener);
+							} catch (e) {
+								// Some browsers don't support 'camera' permission query.
+								// This is not critical - we can still use the camera.
+							}
+						}
+
+						camera.video.srcObject = camera.stream;
+						await camera.video.play();
+
+						// Choose capture method (ordered by efficiency):
+						// 1. WebCodecs + Worker: VideoFrame transferred to Worker, copyTo() in Worker
+						// 2. Worker Canvas 2D: ImageBitmap transferred to Worker, drawImage + getImageData in Worker
+						// 3. WebCodecs (main thread): copyTo() on main thread
+						// 4. Canvas 2D (main thread): drawImage + getImageData on main thread
+						if (GodotCamera.isWebCodecsSupported() && GodotCamera.isWorkerSupported()) {
+							// eslint-disable-next-line require-atomic-updates
+							camera.useWebCodecsWorker = true;
+							GodotCamera.setupWebCodecsWorkerCapture(camera, cameraId, callback, context, deniedCallback);
+						} else if (GodotCamera.isWorkerSupported()) {
+							// eslint-disable-next-line require-atomic-updates
+							camera.useWorker = true;
+							GodotCamera.setupCanvas2DWorkerCapture(camera, cameraId, callback, context, deniedCallback);
+						} else if (GodotCamera.isWebCodecsSupported()) {
+							// eslint-disable-next-line require-atomic-updates
+							camera.useWebCodecs = true;
+							GodotCamera.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
+						} else {
+							GodotCamera.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+						}
+					}
+				} catch (error) {
+					GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, 0, error.message);
+					if (error && (error.name === 'SecurityError' || error.name === 'NotAllowedError')) {
+						deniedCallback(context);
+					}
+				}
+			},
+
+			/**
+			 * Stops camera stream(s).
+			 * @param {string|null} deviceId Device ID to stop, or null to stop all
+			 * @returns {void}
+			 */
+			stop: function (deviceId) {
+				const cameras = GodotCamera.ensureCamerasMap();
+
+				if (deviceId && cameras.has(deviceId)) {
+					const camera = cameras.get(deviceId);
+					if (camera) {
+						GodotCamera.cleanupCamera(camera);
+					}
+					cameras.delete(deviceId);
+				} else {
+					cameras.forEach((camera, id) => {
+						if (camera) {
+							GodotCamera.cleanupCamera(camera);
+						}
+					});
+					cameras.clear();
+				}
+			},
+		},
+	},
+
+	/**
+	 * Native binding for getting list of cameras.
+	 * @param {number} context Context value to pass to callback
+	 * @param {number} callbackPtr1 Pointer to callback function
+	 * @param {number} callbackPtr2 Pointer to callback function
+	 * @returns {Promise<void>}
+	 */
+	godot_js_camera_get_cameras: function (context, callbackPtr1, callbackPtr2) {
+		return GodotCamera.api.getCameras(context, callbackPtr1, callbackPtr2);
+	},
+
+	/**
+	 * Native binding for getting pixel data from camera.
+	 * @param {number} context Context value to pass to callback
+	 * @param {number} deviceIdPtr Pointer to device ID string
+	 * @param {number} width Desired capture width
+	 * @param {number} height Desired capture height
+	 * @param {number} callbackPtr Pointer to callback function
+	 * @param {number} deniedCallbackPtr Pointer to denied callback function
+	 * @returns {*}
+	 */
+	godot_js_camera_get_pixel_data: function (context, deviceIdPtr, width, height, callbackPtr, deniedCallbackPtr) {
+		const deviceId = deviceIdPtr ? GodotRuntime.parseString(deviceIdPtr) : undefined;
+		return GodotCamera.api.getPixelData(context, deviceId, width, height, callbackPtr, deniedCallbackPtr);
+	},
+
+	/**
+	 * Native binding for stopping camera stream.
+	 * @param {number} deviceIdPtr Pointer to device ID string
+	 * @returns {void}
+	 */
+	godot_js_camera_stop_stream: function (deviceIdPtr) {
+		const deviceId = deviceIdPtr ? GodotRuntime.parseString(deviceIdPtr) : undefined;
+		GodotCamera.api.stop(deviceId);
+	},
+};
+
+autoAddDeps(GodotCamera, '$GodotCamera');
+mergeInto(LibraryManager.library, GodotCamera);

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -587,21 +587,26 @@ self.onmessage = async function(event) {
 								format: 'RGBA',
 							});
 
-							const dataPtr = GodotRuntime.malloc(pixelBuffer.length);
-							GodotRuntime.heapCopy(HEAPU8, pixelBuffer, dataPtr);
+							// Reuse cached Wasm heap buffer to avoid per-frame malloc/free.
+							if (GodotCamera._cachedDataSize !== pixelBuffer.length) {
+								if (GodotCamera._cachedDataPtr) {
+									GodotRuntime.free(GodotCamera._cachedDataPtr);
+								}
+								GodotCamera._cachedDataPtr = GodotRuntime.malloc(pixelBuffer.length);
+								GodotCamera._cachedDataSize = pixelBuffer.length;
+							}
+							GodotRuntime.heapCopy(HEAPU8, pixelBuffer, GodotCamera._cachedDataPtr);
 
 							GodotCamera.sendGetPixelDataCallback(
 								callback,
 								context,
-								dataPtr,
+								GodotCamera._cachedDataPtr,
 								pixelBuffer.length,
 								width,
 								height,
 								currentCamera.facingMode,
 								null
 							);
-
-							GodotRuntime.free(dataPtr);
 						} finally {
 							videoFrame.close();
 						}
@@ -829,21 +834,26 @@ self.onmessage = async function(event) {
 						const imageData = currentCamera.canvasContext.getImageData(0, 0, _width, _height);
 						const pixelData = imageData.data;
 
-						const dataPtr = GodotRuntime.malloc(pixelData.length);
-						GodotRuntime.heapCopy(HEAPU8, pixelData, dataPtr);
+						// Reuse cached Wasm heap buffer to avoid per-frame malloc/free.
+						if (GodotCamera._cachedDataSize !== pixelData.length) {
+							if (GodotCamera._cachedDataPtr) {
+								GodotRuntime.free(GodotCamera._cachedDataPtr);
+							}
+							GodotCamera._cachedDataPtr = GodotRuntime.malloc(pixelData.length);
+							GodotCamera._cachedDataSize = pixelData.length;
+						}
+						GodotRuntime.heapCopy(HEAPU8, pixelData, GodotCamera._cachedDataPtr);
 
 						GodotCamera.sendGetPixelDataCallback(
 							callback,
 							context,
-							dataPtr,
+							GodotCamera._cachedDataPtr,
 							pixelData.length,
 							_width,
 							_height,
 							currentCamera.facingMode,
 							null
 						);
-
-						GodotRuntime.free(dataPtr);
 					} catch (error) {
 						GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, error.message);
 

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -1221,7 +1221,7 @@ self.onmessage = async function(event) {
 					}
 					cameras.delete(deviceId);
 				} else {
-					cameras.forEach((camera, id) => {
+					cameras.forEach((camera) => {
 						if (camera) {
 							GodotCamera.cleanupCamera(camera);
 						}

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -291,6 +291,10 @@ async function processVideoFrame(videoFrame) {
 			width: frameWidth,
 			height: frameHeight,
 		};
+	} catch (e) {
+		// Return the buffer to the pool so it is not permanently lost on error.
+		bufferPool.push(arrayBuffer);
+		throw e;
 	} finally {
 		videoFrame.close();
 	}

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -414,17 +414,6 @@ self.onmessage = async function(event) {
 		},
 
 		/**
-		 * Ensures cameras Map is properly initialized.
-		 * @returns {Map<string, CameraResource>}
-		 */
-		ensureCamerasMap: function () {
-			if (!this.cameras || !(this.cameras instanceof Map)) {
-				this.cameras = new Map();
-			}
-			return this.cameras;
-		},
-
-		/**
 		 * Cleanup all camera resources.
 		 * @returns {void}
 		 */
@@ -560,7 +549,7 @@ self.onmessage = async function(event) {
 			camera.frameReader = camera.trackProcessor.readable.getReader();
 
 			const processFrames = async () => {
-				const cameras = GodotCamera.ensureCamerasMap();
+				const cameras = GodotCamera.cameras;
 				try {
 					while (true) {
 						const currentCamera = cameras.get(cameraId);
@@ -722,7 +711,7 @@ self.onmessage = async function(event) {
 
 			// Start the frame reading loop
 			const processFrames = async () => {
-				const cameras = GodotCamera.ensureCamerasMap();
+				const cameras = GodotCamera.cameras;
 				try {
 					while (true) {
 						const currentCamera = cameras.get(cameraId);
@@ -790,7 +779,7 @@ self.onmessage = async function(event) {
 			}
 
 			const captureFrame = () => {
-				const cameras = GodotCamera.ensureCamerasMap();
+				const cameras = GodotCamera.cameras;
 				const currentCamera = cameras.get(cameraId);
 				if (!currentCamera) {
 					return;
@@ -943,7 +932,7 @@ self.onmessage = async function(event) {
 
 			// Start the frame capture loop.
 			const captureFrame = () => {
-				const cameras = GodotCamera.ensureCamerasMap();
+				const cameras = GodotCamera.cameras;
 				const currentCamera = cameras.get(cameraId);
 				if (!currentCamera || !currentCamera.useWorker || !currentCamera.worker) {
 					return;
@@ -1118,8 +1107,8 @@ self.onmessage = async function(event) {
 				const cameraId = deviceId || 'default';
 
 				try {
-					const camerasMap = GodotCamera.ensureCamerasMap();
-					let camera = camerasMap.get(cameraId);
+					const cameras = GodotCamera.cameras;
+					let camera = cameras.get(cameraId);
 					if (!camera) {
 						camera = {
 							video: null,
@@ -1137,7 +1126,7 @@ self.onmessage = async function(event) {
 							useWorker: false,
 							facingMode: 0,
 						};
-						camerasMap.set(cameraId, camera);
+						cameras.set(cameraId, camera);
 					}
 
 					if (!camera.stream) {
@@ -1223,7 +1212,7 @@ self.onmessage = async function(event) {
 			 * @returns {void}
 			 */
 			stop: function (deviceId) {
-				const cameras = GodotCamera.ensureCamerasMap();
+				const cameras = GodotCamera.cameras;
 
 				if (deviceId && cameras.has(deviceId)) {
 					const camera = cameras.get(deviceId);

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -74,6 +74,19 @@ const GodotCamera = {
 		 */
 		workerBlobUrl: null,
 
+		/**
+		 * Cached Wasm heap pointer for frame data copy.
+		 * Avoids per-frame malloc/free overhead and fragmentation.
+		 * @type {number}
+		 */
+		_cachedDataPtr: 0,
+
+		/**
+		 * Size of the cached Wasm heap buffer.
+		 * @type {number}
+		 */
+		_cachedDataSize: 0,
+
 		defaultMinimumCapabilities: {
 			'width': {
 				'min': 1,
@@ -191,6 +204,30 @@ let width = 0;
 let height = 0;
 let isCapturing = false;
 
+// Buffer pool state
+let bufferPool = [];
+let currentBufferSize = 0;
+const POOL_SIZE = 4;
+
+function ensureBufferPool(requiredSize) {
+	if (requiredSize === currentBufferSize) {
+		return;
+	}
+	// Resolution changed - reallocate pool.
+	currentBufferSize = requiredSize;
+	bufferPool = [];
+	for (let i = 0; i < POOL_SIZE; i++) {
+		bufferPool.push(new ArrayBuffer(currentBufferSize));
+	}
+}
+
+function acquireBuffer() {
+	if (bufferPool.length === 0) {
+		return null;
+	}
+	return bufferPool.pop();
+}
+
 // Process ImageBitmap using Canvas 2D (fallback method)
 function processImageBitmap(imageBitmap) {
 	const frameWidth = imageBitmap.width;
@@ -208,8 +245,19 @@ function processImageBitmap(imageBitmap) {
 	const imageData = canvasContext.getImageData(0, 0, width, height);
 	imageBitmap.close();
 
+	const requiredSize = width * height * 4;
+	ensureBufferPool(requiredSize);
+
+	const arrayBuffer = acquireBuffer();
+	if (arrayBuffer === null) {
+		return null;
+	}
+
+	const poolBuffer = new Uint8Array(arrayBuffer);
+	poolBuffer.set(imageData.data);
+
 	return {
-		pixelData: imageData.data,
+		pixelData: poolBuffer,
 		width: width,
 		height: height,
 	};
@@ -219,8 +267,17 @@ function processImageBitmap(imageBitmap) {
 async function processVideoFrame(videoFrame) {
 	const frameWidth = videoFrame.displayWidth;
 	const frameHeight = videoFrame.displayHeight;
-	const bufferSize = frameWidth * frameHeight * 4;
-	const pixelBuffer = new Uint8Array(bufferSize);
+	const requiredSize = frameWidth * frameHeight * 4;
+
+	ensureBufferPool(requiredSize);
+
+	const arrayBuffer = acquireBuffer();
+	if (arrayBuffer === null) {
+		videoFrame.close();
+		return null;
+	}
+
+	const pixelBuffer = new Uint8Array(arrayBuffer);
 
 	try {
 		await videoFrame.copyTo(pixelBuffer, {
@@ -249,7 +306,18 @@ self.onmessage = async function(event) {
 		height = data.height || 480;
 		canvasContext = canvas.getContext('2d', { willReadFrequently: true });
 		isCapturing = true;
+		currentBufferSize = width * height * 4;
+		bufferPool = [];
+		for (let i = 0; i < POOL_SIZE; i++) {
+			bufferPool.push(new ArrayBuffer(currentBufferSize));
+		}
 		self.postMessage({ type: 'initialized' });
+		break;
+
+	case 'returnBuffer':
+		if (data.buffer && data.buffer.byteLength === currentBufferSize) {
+			bufferPool.push(data.buffer);
+		}
 		break;
 
 	case 'videoFrame':
@@ -263,6 +331,9 @@ self.onmessage = async function(event) {
 
 		try {
 			const result = await processVideoFrame(data.videoFrame);
+			if (result === null) {
+				return;
+			}
 			self.postMessage(
 				{
 					type: 'frameData',
@@ -292,6 +363,9 @@ self.onmessage = async function(event) {
 
 		try {
 			const result = processImageBitmap(data.imageBitmap);
+			if (result === null) {
+				return;
+			}
 			self.postMessage(
 				{
 					type: 'frameData',
@@ -314,6 +388,8 @@ self.onmessage = async function(event) {
 		isCapturing = false;
 		canvas = null;
 		canvasContext = null;
+		bufferPool = [];
+		currentBufferSize = 0;
 		self.postMessage({ type: 'stopped' });
 		break;
 
@@ -350,6 +426,13 @@ self.onmessage = async function(event) {
 		 */
 		cleanup: function () {
 			this.api.stop();
+
+			// Free cached Wasm heap buffer.
+			if (this._cachedDataPtr) {
+				GodotRuntime.free(this._cachedDataPtr);
+				this._cachedDataPtr = 0;
+				this._cachedDataSize = 0;
+			}
 
 			// Revoke worker blob URL to free memory.
 			if (this.workerBlobUrl) {
@@ -400,15 +483,23 @@ self.onmessage = async function(event) {
 		 * @param {number} context Context value to pass to callback
 		 * @returns {void}
 		 */
-		handleWorkerFrameData: function (eventData, callback, context) {
+		handleWorkerFrameData: function (eventData, callback, context, worker) {
 			const { pixelData, width, height, facingMode } = eventData;
-			const dataPtr = GodotRuntime.malloc(pixelData.length);
-			GodotRuntime.heapCopy(HEAPU8, pixelData, dataPtr);
+
+			// Reuse cached Wasm heap buffer to avoid per-frame malloc/free.
+			if (GodotCamera._cachedDataSize !== pixelData.length) {
+				if (GodotCamera._cachedDataPtr) {
+					GodotRuntime.free(GodotCamera._cachedDataPtr);
+				}
+				GodotCamera._cachedDataPtr = GodotRuntime.malloc(pixelData.length);
+				GodotCamera._cachedDataSize = pixelData.length;
+			}
+			GodotRuntime.heapCopy(HEAPU8, pixelData, GodotCamera._cachedDataPtr);
 
 			GodotCamera.sendGetPixelDataCallback(
 				callback,
 				context,
-				dataPtr,
+				GodotCamera._cachedDataPtr,
 				pixelData.length,
 				width,
 				height,
@@ -416,7 +507,13 @@ self.onmessage = async function(event) {
 				null
 			);
 
-			GodotRuntime.free(dataPtr);
+			// Return used buffer to worker pool.
+			if (worker && pixelData.buffer.byteLength > 0) {
+				worker.postMessage(
+					{ type: 'returnBuffer', data: { buffer: pixelData.buffer } },
+					[pixelData.buffer]
+				);
+			}
 		},
 
 		/**
@@ -489,8 +586,6 @@ self.onmessage = async function(event) {
 							const dataPtr = GodotRuntime.malloc(pixelBuffer.length);
 							GodotRuntime.heapCopy(HEAPU8, pixelBuffer, dataPtr);
 
-							const facingMode = GodotCamera.getFacingMode(currentCamera.stream);
-
 							GodotCamera.sendGetPixelDataCallback(
 								callback,
 								context,
@@ -498,7 +593,7 @@ self.onmessage = async function(event) {
 								pixelBuffer.length,
 								width,
 								height,
-								facingMode,
+								currentCamera.facingMode,
 								null
 							);
 
@@ -571,7 +666,7 @@ self.onmessage = async function(event) {
 
 				switch (type) {
 				case 'frameData':
-					GodotCamera.handleWorkerFrameData(event.data, callback, context);
+					GodotCamera.handleWorkerFrameData(event.data, callback, context, camera.worker);
 					break;
 
 				case 'error':
@@ -632,15 +727,13 @@ self.onmessage = async function(event) {
 							break;
 						}
 
-						const facingMode = GodotCamera.getFacingMode(currentCamera.stream);
-
 						// Transfer VideoFrame to worker
 						currentCamera.worker.postMessage(
 							{
 								type: 'videoFrame',
 								data: {
 									videoFrame,
-									facingMode,
+									facingMode: currentCamera.facingMode,
 								},
 							},
 							[videoFrame]
@@ -735,8 +828,6 @@ self.onmessage = async function(event) {
 						const dataPtr = GodotRuntime.malloc(pixelData.length);
 						GodotRuntime.heapCopy(HEAPU8, pixelData, dataPtr);
 
-						const facingMode = GodotCamera.getFacingMode(stream);
-
 						GodotCamera.sendGetPixelDataCallback(
 							callback,
 							context,
@@ -744,7 +835,7 @@ self.onmessage = async function(event) {
 							pixelData.length,
 							_width,
 							_height,
-							facingMode,
+							currentCamera.facingMode,
 							null
 						);
 
@@ -801,7 +892,7 @@ self.onmessage = async function(event) {
 
 				switch (type) {
 				case 'frameData':
-					GodotCamera.handleWorkerFrameData(event.data, callback, context);
+					GodotCamera.handleWorkerFrameData(event.data, callback, context, camera.worker);
 					break;
 
 				case 'error':
@@ -862,14 +953,12 @@ self.onmessage = async function(event) {
 								return;
 							}
 
-							const facingMode = GodotCamera.getFacingMode(cam.stream);
-
 							cam.worker.postMessage(
 								{
 									type: 'frame',
 									data: {
 										imageBitmap,
-										facingMode,
+										facingMode: cam.facingMode,
 									},
 								},
 								[imageBitmap]
@@ -1032,6 +1121,7 @@ self.onmessage = async function(event) {
 							useWebCodecsWorker: false,
 							useWebCodecs: false,
 							useWorker: false,
+							facingMode: 0,
 						};
 						camerasMap.set(cameraId, camera);
 					}
@@ -1084,21 +1174,21 @@ self.onmessage = async function(event) {
 						camera.video.srcObject = camera.stream;
 						await camera.video.play();
 
+						// Cache facing mode once (doesn't change during stream).
+						camera.facingMode = GodotCamera.getFacingMode(camera.stream);
+
 						// Choose capture method (ordered by efficiency):
 						// 1. WebCodecs + Worker: VideoFrame transferred to Worker, copyTo() in Worker
 						// 2. Worker Canvas 2D: ImageBitmap transferred to Worker, drawImage + getImageData in Worker
 						// 3. WebCodecs (main thread): copyTo() on main thread
 						// 4. Canvas 2D (main thread): drawImage + getImageData on main thread
 						if (GodotCamera.isWebCodecsSupported() && GodotCamera.isWorkerSupported()) {
-							// eslint-disable-next-line require-atomic-updates
 							camera.useWebCodecsWorker = true;
 							GodotCamera.setupWebCodecsWorkerCapture(camera, cameraId, callback, context, deniedCallback);
 						} else if (GodotCamera.isWorkerSupported()) {
-							// eslint-disable-next-line require-atomic-updates
 							camera.useWorker = true;
 							GodotCamera.setupCanvas2DWorkerCapture(camera, cameraId, callback, context, deniedCallback);
 						} else if (GodotCamera.isWebCodecsSupported()) {
-							// eslint-disable-next-line require-atomic-updates
 							camera.useWebCodecs = true;
 							GodotCamera.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
 						} else {


### PR DESCRIPTION
```cpp
image->initialize_data(p_width, p_height, false, Image::FORMAT_RGBA8, data);
```

Causes data's underlying CoW data structure to be obtained by `image`, taking its reference count from 1 to 2.

Next frame we call `data.ptrw()` which is implemented as:

```
	_FORCE_INLINE_ T *ptrw() {
		// If forking fails, we can only crash.
		CRASH_COND(_copy_on_write());
		return _ptr;
	}
```
https://github.com/godotengine/godot/blob/master/core/templates/cowdata.h#L164-L168

```
template <typename T>
Error CowData<T>::_copy_on_write() {
	if (!_ptr || _get_refcount()->get() == 1) {
		// Nothing to do.
		return OK;
	}

	// Fork to become the only reference.
	return _copy_to_new_buffer_exact(capacity(), size(), 0, 0);
}
```
https://github.com/godotengine/godot/blob/master/core/templates/cowdata.h#L539-L548

Because the reference count is now 2, rather than 1, we call through to `_copy_to_new_buffer_exact`.

This sequence continues every subsequent frame, creating a new buffer. We're not leaking these buffers, but we are re-allocating frequently.

In practice this was observed leading to crashes because the repeated allocations fragment the SharedArrayBuffer backing WASM memory region eventually leading to a memory allocation failure. In testing this was fairly consistently reproducible by opening the web camera view and leaving it running for a few minutes.

The fix is just to eliminate the intermediary data buffer and write directly to the image data. Its data is only referenced by the image, and thus there's no allocations taking place when we get its pointer with `ptrw()`

---

I'm not expecting you to actually merge this PR. Feel free to just make the same / similar edits yourself and close. This was just the easy way to get this information to you.

Thanks for your work on this features 🙏 